### PR TITLE
Fix CORS issue with vite server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import dns from "dns";
+
+// Display localhost instead of 127.0.0.1 for CORS purposes.
+// See [this](https://vitejs.dev/config/server-options.html#server-host).
+dns.setDefaultResultOrder("verbatim");
 
 export default defineConfig(() => {
   return {
     build: {
       outDir: "build",
+    },
+    server: {
+      port: 3000,
     },
     plugins: [react()],
   };


### PR DESCRIPTION
* Displays `  ➜  Local:   http://localhost:3000/` instead of `  ➜  Local:   http://127.0.0.1:3000/` because the mock server has CORS setup for `localhost` only.
* Change port to `3000` because that's what the mock server expects.